### PR TITLE
Get HYPERFOIL_HOME from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ scripts/hyperfoil*
 
 # Ignore html results
 scripts/*.html
+
+# Ignore jfr results
+scripts/*.jfr

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HYPERFOIL_HOME=./hyperfoil
+HYPERFOIL_HOME=${HYPERFOIL_HOME:-./hyperfoil}
 
 URL=hello
 


### PR DESCRIPTION
Simple improvement:

Get the `HYPERFOIL_HOME` from the shell environment if existing, otherwise fallback to the defaul "./hyperfoil".
With this, anyone could run the `./benchmark` script  overriding the Hyperfoil home folder without changing the script itself, e.g., `HYPERFOIL_HOME=/home/alampare/tools/hyperfoil-0.25.2 ./benchmark.sh -u persons/agesum -r 4000 -e cache-misses -f jfr`